### PR TITLE
docs: fix simple typo, colleciton -> collection

### DIFF
--- a/cointrol/server/api/pagination.py
+++ b/cointrol/server/api/pagination.py
@@ -1,5 +1,5 @@
 """
-Custom colleciton pagination
+Custom collection pagination
 
 """
 from collections import OrderedDict


### PR DESCRIPTION
There is a small typo in cointrol/server/api/pagination.py.

Should read `collection` rather than `colleciton`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md